### PR TITLE
Improve default flyspell behavior by defining a custom predicate

### DIFF
--- a/salt-mode.el
+++ b/salt-mode.el
@@ -72,6 +72,16 @@
   :group 'salt
   :safe 'integerp)
 
+(defun salt--flyspell-predicate ()
+  "Only spellcheck comments and documentation within salt-mode.
+
+Salt strings are usually configuration file data, and not
+suitable for spellchecking."
+  (memq (get-text-property (- (point) 1) 'face)
+        '(font-lock-comment-face font-lock-doc-face)))
+
+(put 'salt-mode 'flyspell-mode-predicate #'salt--flyspell-predicate)
+
 ;;;###autoload
 (define-derived-mode salt-mode yaml-mode "SaltStack"
   "A major mode to edit Salt States."


### PR DESCRIPTION
`salt-mode` is a `text-mode`, not a `prog-mode`; most global-on flyspell
configurations will enable full spellchecking, which is not very
useful. However, even `flyspell-prog-mode` is not a good default, since
strings in SLS files are usually just some other configuration file
format, or a minion target, etc., which should not be spellchecked.
Instead, we want to restrict spellchecking by default to comments
and documentation only.

If flyspell is not on, setting a predicate should have no effect.