### PR TITLE
Add salt-open-doc to browse state documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This uses [mmm-mode][] and [mmm-jinja2][] to hook up Jinja2 templates into YAML 
 * Indentation and alignment of expressions and statements
 * Jinja Templating Support
 * Spell checking of comments with flyspell
+* Open documentation for state functions
 
 ## Installation
 
@@ -42,6 +43,12 @@ To enable flyspell for comments when using the mode:
         (lambda ()
             (flyspell-mode 1)))
 ```
+
+### State documentation
+
+Use `salt-open-doc` to browse the documentation of the state module at point.
+
+When run with a prefix argument, prompt for the state module to use.
 
 ## Support
 

--- a/salt-mode.el
+++ b/salt-mode.el
@@ -82,7 +82,7 @@ suitable for spellchecking."
 
 (put 'salt-mode 'flyspell-mode-predicate #'salt-mode--flyspell-predicate)
 
-(defun salt--state-module-at-point ()
+(defun salt-mode--state-module-at-point ()
   "Get the state module at point, either pkg or pkg.installed, or return nil."
   (save-excursion
     (when (looking-back ":" 1)
@@ -98,9 +98,9 @@ suitable for spellchecking."
                           (string-trim (buffer-substring-no-properties start end)))))
       (if (string= "" module) nil module))))
 
-(defun salt--doc-read-arg ()
-  "Get the argument for interactively calling `salt-open-doc'"
-  (let* ((default (salt--state-module-at-point))
+(defun salt-mode--doc-read-arg ()
+  "Get the argument for interactively calling `salt-mode-browse-doc'"
+  (let* ((default (salt-mode--state-module-at-point))
          (prompt (if default
                      (format "Open salt doc (%s): " default)
                    "Open salt doc, e.g. file.managed: "))
@@ -109,8 +109,8 @@ suitable for spellchecking."
                  default)))
     (list word)))
 
-(defun salt-open-doc (module)
-  "Open the documentation for the state module `MODULE'.
+(defun salt-mode-browse-doc (module)
+  "Browse to the documentation for the state module `MODULE'.
 
 `MODULE' may be the name of a state module (pkg), or the name of a
 state module and method (pkg.installed).
@@ -119,7 +119,7 @@ When called interactively, use the module at point.
 If no module is found or a prefix argument is supplied, prompt for the
 module to use.
 "
-  (interactive (salt--doc-read-arg))
+  (interactive (salt-mode--doc-read-arg))
   (let* ((pieces (split-string module "\\." t " +"))
          (module (car pieces))
          (url (format "https://docs.saltstack.com/en/latest/ref/states/all/salt.states.%s.html" module))

--- a/salt-mode.el
+++ b/salt-mode.el
@@ -82,6 +82,50 @@ suitable for spellchecking."
 
 (put 'salt-mode 'flyspell-mode-predicate #'salt--flyspell-predicate)
 
+(defun salt--state-module-at-point ()
+  "Get the state module at point, either pkg or pkg.installed, or return nil."
+  (save-excursion
+    (when (looking-back ":" 1)
+      (backward-char))
+    (skip-chars-forward " ")
+    (let* (start
+           end
+           (module (progn (skip-chars-backward "_.a-z0-9")
+                          (setq start (point))
+                          (forward-char)
+                          (skip-chars-forward "_.a-z0-9")
+                          (setq end (point))
+                          (string-trim (buffer-substring-no-properties start end)))))
+      (if (string= "" module) nil module))))
+
+(defun salt--doc-read-arg ()
+  "Get the argument for interactively calling `salt-open-doc'"
+  (let* ((default (salt--state-module-at-point))
+         (prompt (if default
+                     (format "Open salt doc (%s): " default)
+                   "Open salt doc, e.g. file.managed: "))
+         (word (if (or current-prefix-arg (not default))
+                   (completing-read prompt nil nil nil nil nil default)
+                 default)))
+    (list word)))
+
+(defun salt-open-doc (module)
+  "Open the documentation for the state module `MODULE'.
+
+`MODULE' may be the name of a state module (pkg), or the name of a
+state module and method (pkg.installed).
+
+When called interactively, use the module at point.
+If no module is found or a prefix argument is supplied, prompt for the
+module to use.
+"
+  (interactive (salt--doc-read-arg))
+  (let* ((pieces (split-string module "\\." t " +"))
+         (module (car pieces))
+         (url (format "https://docs.saltstack.com/en/latest/ref/states/all/salt.states.%s.html" module))
+         (method (cadr pieces)))
+    (browse-url (if method (concat url "#salt.states." module "." method) url))))
+
 (defconst salt-mode-toplevel-keywords
   '("include" "exclude" "extend")
   "Keys with special meaning at the top level of state files.")


### PR DESCRIPTION
@joewreschnig if you get a moment, can you give this function a try?