### PR TITLE
Fix yaml indent offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,18 @@
-# Salt Mode
+# Salt-mode
 
 [![License GPL 3][badge-license]][copying]
 [![Build Status][badge-travis]][travis]
 [![MELPA Badge][badge-melpa]][melpa]
 [![MELPA Stable Badge][badge-melpa-stable]][melpa-stable]
 
-Salt Mode lets you edit [Salt][] states with [GNU Emacs][] 24.
+Salt-mode is a [GNU Emacs][] major mode for editing [SaltStack][] state files.
 
-Salt Mode is a major mode for [GNU Emacs][] 24 which adds support for
-[Salt][] state syntax. Salt is a different approach to infrastructure management, 
-founded on the idea that high-speed communication with large numbers of systems 
-can open up new capabilities by [SaltStack][]. On top of this communication system,
- Salt provides an extremely fast, flexible, and easy-to-use configuration management 
-system called Salt States.
+[Salt] is a Python-based configuration management and orchestration
+system built on top of a high-speed remote execution engine.
+Configuration management is most commonly managed by writing state files ending with `.sls`;
+this mode adds emacs support for these files.
 
-This mode has only been tested in GNU Emacs 24. It may **not** work with GNU Emacs 23 and below,
-or with other flavors of Emacs (e.g. XEmacs).
+Salt-mode requires an emacs version greater than 24.3.
 
 This uses [mmm-mode][] and [mmm-jinja2][] to hook up Jinja2 templates into YAML (essentially what SaltStack files are).
 
@@ -26,6 +23,7 @@ This uses [mmm-mode][] and [mmm-jinja2][] to hook up Jinja2 templates into YAML 
 * Jinja Templating Support
 * Spell checking of comments with flyspell
 * Open documentation for state functions
+* Navigation by state function
 
 ## Installation
 
@@ -53,6 +51,10 @@ Use `salt-mode-browse-doc` to browse the documentation of the state module at po
 
 When run with a prefix argument, prompt for the state module to use.
 
+### Function jumping
+
+Use `salt-mode-forward-state-function` and `salt-mode-backward-state-function`, bound by default to <kbd>C-M-b</kbd> and <kbd>C-M-f</kbd>, to navigate by salt function.
+
 ## Support
 
 Feel free to ask questions or make suggestions in the [issue tracker][] on [github][].
@@ -75,12 +77,12 @@ You can also use the .sls files in `test/` to test various mode functions.
 
 ## License
 
-Salt Mode is free software: you can redistribute it and/or modify it under the
+Salt-mode is free software: you can redistribute it and/or modify it under the
 terms of the GNU General Public License as published by the Free Software
 Foundation, either version 3 of the License, or (at your option) any later
 version.
 
-Salt Mode is distributed in the hope that it will be useful, but WITHOUT ANY
+Salt-mode is distributed in the hope that it will be useful, but WITHOUT ANY
 WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 PARTICULAR PURPOSE. See the GNU General Public License for more details.
 

--- a/salt-mode.el
+++ b/salt-mode.el
@@ -246,6 +246,8 @@ https://docs.saltstack.com/en/latest/ref/states/requisites.html")
         electric-indent-inhibit t
         mmm-global-mode 'maybe)
 
+  (setq-local yaml-indent-offset salt-mode-indent-level)
+
   (mmm-add-mode-ext-class 'salt-mode "\\.sls\\'" 'jinja2)
   (font-lock-add-keywords nil salt-mode-keywords))
 

--- a/salt-mode.el
+++ b/salt-mode.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/glynnforrest/salt-mode
 ;; Keywords: languages
 ;; Version: 0.1
-;; Package-Requires: ((yaml-mode "0.0.12") (mmm-mode "0.5.4") (mmm-jinja2 "0.1"))
+;; Package-Requires: ((emacs "24.3") (yaml-mode "0.0.12") (mmm-mode "0.5.4") (mmm-jinja2 "0.1"))
 
 ;; This file is not part of GNU Emacs.
 

--- a/test/init.el
+++ b/test/init.el
@@ -13,4 +13,11 @@
     (unless (package-installed-p pkg)
   (package-install pkg)))
 
+;; salt-mode should set yaml indentation without changing it globally
+;; The default is 2 - the value of salt-mode-indent-level.
+;; Opening test/simple.sls with this config should have a buffer local
+;; indent offset of 2, but regular yaml files should still be 4.
+(require 'yaml-mode)
+(setq yaml-indent-offset 4)
+
 (require 'salt-mode (concat salt-mode-root-dir "salt-mode.el"))

--- a/test/simple.sls
+++ b/test/simple.sls
@@ -1,27 +1,26 @@
 some_service:
-    pkg.installed
-    file.managed:
-        - source: salt://some_service.j2
-        - template: jinja
-    service.running:
-        - name: some_service
-        - enable: True
-        - require:
-            - pkg: some_service
-            - file: some_service
+  pkg.installed
+  file.managed:
+    - source: salt://some_service.j2
+    - template: jinja
+  service.running:
+    - name: some_service
+    - enable: True
+    - require:
+      - pkg: some_service
+      - file: some_service
 
 state with spaces:
-    cmd.run:
-        - name: 'hostname'
+  cmd.run:
+    - name: 'hostname'
 
 /etc/some_service/file.conf:
-    pkg.installed:
-        - source: salt://file.conf
-
+  pkg.installed:
+    - source: salt://file.conf
 
 state_with_newlines:
-    cmd.run:
-        - name: 'cat /etc/passwd'
+  cmd.run:
+    - name: 'cat /etc/passwd'
 
-    service.dead:
-        - name: sshd
+  service.dead:
+    - name: sshd


### PR DESCRIPTION
An interesting yaml-mode idiosyncrasy is that it doesn't respect `tab-width`, instead using `yaml-indent-offset` to determine how many spaces to use for indentation.

This variable seems to be global, so I've added a `setq-local` call to make it match up with `salt-mode-indent-level`.

This means the mode now requires emacs 24.3 to use `setq-local`. I think this is reasonable, given that version was released in March 2013 https://lists.gnu.org/archive/html/info-gnu-emacs/2013-03/msg00001.html

@joewreschnig does this version requirement sound good to you?