### PR TITLE
Add font-lock for salt:// file sources

### DIFF
--- a/salt-mode.el
+++ b/salt-mode.el
@@ -467,7 +467,7 @@ https://docs.saltstack.com/en/latest/ref/states/top.html")
   :group 'salt)
 
 (defface salt-mode-file-source-face
-  '((t (:inherit font-lock-constant-face)))
+  '((t (:inherit font-lock-builtin-face)))
   "Face for salt:// in Salt file sources."
   :group 'salt)
 

--- a/salt-mode.el
+++ b/salt-mode.el
@@ -466,6 +466,11 @@ https://docs.saltstack.com/en/latest/ref/states/top.html")
   "Face for Salt minion match types."
   :group 'salt)
 
+(defface salt-mode-file-source-face
+  '((t (:inherit font-lock-constant-face)))
+  "Face for salt:// in Salt file sources."
+  :group 'salt)
+
 (defconst salt-mode-keywords
   `((,(format "^%s:" (regexp-opt salt-mode-toplevel-keywords t))
      (1 'salt-mode-keyword-face))
@@ -475,6 +480,8 @@ https://docs.saltstack.com/en/latest/ref/states/top.html")
      (1 'salt-mode-state-id-face))
     ("^ +\\([a-z][a-z0-9_]*\\.[a-z][a-z0-9_]*\\):?"
      (1 'salt-mode-state-function-face))
+    (": *\\(salt://\\)"
+     (1 'salt-mode-file-source-face))
     ;; TODO:
     ;; - Match state IDs in extend: forms and requisite lists.
     ;; - Don't match requisites unless they're under functions.

--- a/test/salt-mode-test.el
+++ b/test/salt-mode-test.el
@@ -37,8 +37,9 @@ state_two:
   (salt-test--with-buffer
    "
 remove_vim:
-  pkg.removed:
-    - name: vim
+  file.managed:
+    - name: ~/.emacs.d/init.el
+    - source: salt://init.el
     - require:
       - pkg: install_emacs
 "
@@ -49,6 +50,9 @@ remove_vim:
    (forward-char 2)
    (should (equal 'salt-mode-state-function-face (salt-test--face-at-point)))
 
-   (forward-line 2)
+   (re-search-forward "salt:")
+   (should (equal 'salt-mode-file-source-face (salt-test--face-at-point)))
+
+   (forward-line)
    (forward-char 6)
    (should (equal 'salt-mode-requisite-face (salt-test--face-at-point)))))


### PR DESCRIPTION
@joewreschnig I'm not so sure about the look of this, what do you think? I do want to highlight `salt://` in some way so it stands out however.

![screen shot 2017-07-02 at 03 58 30](https://user-images.githubusercontent.com/578458/27766941-fe8d135c-5eda-11e7-930a-734a0d3539a5.png)


I've added a basic unit test setup, and working on a way to test font-locking.