### PR TITLE
Use font-lock functions that are available in 24.4

### DIFF
--- a/salt-mode.el
+++ b/salt-mode.el
@@ -513,7 +513,10 @@ https://docs.saltstack.com/en/latest/ref/states/top.html")
          ((equal (file-name-nondirectory buffer-file-name) "top.sls")
           salt-mode-top-file-keywords)
          (t salt-mode-keywords)))
-  (font-lock-defontify))
+  (if (fboundp 'font-lock-flush)
+      (font-lock-flush)
+    ;; use defontify as a fallback in emacs 24
+    (font-lock-defontify)))
 
 (add-to-list 'mmm-set-file-name-for-modes 'salt-mode)
 (mmm-add-mode-ext-class 'salt-mode "\\.sls\\'" 'jinja2)

--- a/salt-mode.el
+++ b/salt-mode.el
@@ -513,7 +513,7 @@ https://docs.saltstack.com/en/latest/ref/states/top.html")
          ((equal (file-name-nondirectory buffer-file-name) "top.sls")
           salt-mode-top-file-keywords)
          (t salt-mode-keywords)))
-  (font-lock-flush))
+  (font-lock-defontify))
 
 (add-to-list 'mmm-set-file-name-for-modes 'salt-mode)
 (mmm-add-mode-ext-class 'salt-mode "\\.sls\\'" 'jinja2)

--- a/test/salt-mode-test.el
+++ b/test/salt-mode-test.el
@@ -32,3 +32,23 @@ state_two:
       nil
       "cmd.run"
       nil))))
+
+(ert-deftest salt-test-font-lock ()
+  (salt-test--with-buffer
+   "
+remove_vim:
+  pkg.removed:
+    - name: vim
+    - require:
+      - pkg: install_emacs
+"
+   (forward-line)
+   (should (equal 'salt-mode-state-id-face (salt-test--face-at-point)))
+
+   (forward-line)
+   (forward-char 2)
+   (should (equal 'salt-mode-state-function-face (salt-test--face-at-point)))
+
+   (forward-line 2)
+   (forward-char 6)
+   (should (equal 'salt-mode-requisite-face (salt-test--face-at-point)))))

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -8,4 +8,9 @@
      (salt-mode)
      (insert ,contents)
      (goto-char (point-min))
+     (font-lock-fontify-buffer)
      ,@body))
+
+(defun salt-test--face-at-point ()
+  "Get the face at the current point."
+  (get-char-property (point) 'face))


### PR DESCRIPTION
It doesn't look like `(font-lock-flush)` is available in 24.4, so the build is breaking now that there are actual tests running:
https://travis-ci.org/glynnforrest/salt-mode/builds/249250857#L738

I think `(font-lock-defontify)` does what you want @joewreschnig, can you confirm?