### PR TITLE
Fix compatibility issue with evil bindings

### DIFF
--- a/salt-mode.el
+++ b/salt-mode.el
@@ -525,19 +525,20 @@ https://docs.saltstack.com/en/latest/ref/states/top.html")
 
 (defun salt-mode--set-keywords ()
   "Set keywords appropriate for the current SLS file type."
-  (font-lock-remove-keywords nil salt-mode-top-file-keywords)
-  (font-lock-remove-keywords nil salt-mode-keywords)
-  (font-lock-add-keywords
-   nil
-   (cond ((null buffer-file-name)
-          salt-mode-keywords)
-         ((equal (file-name-nondirectory buffer-file-name) "top.sls")
-          salt-mode-top-file-keywords)
-         (t salt-mode-keywords)))
-  (if (fboundp 'font-lock-flush)
-      (font-lock-flush)
-    ;; use defontify as a fallback in emacs 24
-    (font-lock-defontify)))
+  (when (string= major-mode "salt-mode")
+    (font-lock-remove-keywords nil salt-mode-top-file-keywords)
+    (font-lock-remove-keywords nil salt-mode-keywords)
+    (font-lock-add-keywords
+     nil
+     (cond ((null buffer-file-name)
+            salt-mode-keywords)
+           ((equal (file-name-nondirectory buffer-file-name) "top.sls")
+            salt-mode-top-file-keywords)
+           (t salt-mode-keywords)))
+    (if (fboundp 'font-lock-flush)
+        (font-lock-flush)
+      ;; use defontify as a fallback in emacs 24
+      (font-lock-defontify))))
 
 (add-to-list 'mmm-set-file-name-for-modes 'salt-mode)
 (mmm-add-mode-ext-class 'salt-mode "\\.sls\\'" 'jinja2)
@@ -558,7 +559,7 @@ required.)"
   (setq-local yaml-indent-offset salt-mode-indent-level)
   (setq-local eldoc-documentation-function #'salt-mode--eldoc)
   (salt-mode--set-keywords)
-  (add-hook 'buffer-list-update-hook #'salt-mode--set-keywords nil t)
+  (add-hook 'post-command-hook #'salt-mode--set-keywords nil t)
   (unless mmm-in-temp-buffer
     (salt-mode-refresh-data t)))
 


### PR DESCRIPTION
The use of `buffer-list-update-hook` interferes with 
evil key bindings, by indirectly resetting temporary key
map used for evil operator pending state.

I suggest switching to `post-command-hook`. It should
provide similar behavior but will be safer alternative.

Although please test, whether previous functionality is
still there, as it wasn't too clear for me what that function
should be doing.

Related issue: https://github.com/syl20bnr/spacemacs/issues/9707